### PR TITLE
Maybe some useful text tweaks?

### DIFF
--- a/docs/get-started/elements.md
+++ b/docs/get-started/elements.md
@@ -4,7 +4,7 @@ title: "Template and Slot Elements"
 
 # Template and Slot Elements
 
-Two handy elements for creating content fragments and passing content to components you might not be familiar with are <template> and <slot>.
+Two handy elements for creating content fragments and passing content to components that you might not be familiar with are `<template>` and `<slot>`.
 
 ## `<template>`
 

--- a/docs/get-started/elements.md
+++ b/docs/get-started/elements.md
@@ -4,11 +4,13 @@ title: "Template and Slot Elements"
 
 # Template and Slot Elements
 
-The Web Components specification brings two elements to the Web Platform, `<template>` and `<slot>`, for creating content fragments and passing content in to components.
+There are two elements which can be very useful in creating Web Components which you might not be familliar with: `<template>` and `<slot>`, for creating content fragments and passing content in to components.
 
 ## `<template>`
 
-The `template` element is a Web Standard for creating content fragments for reuse later in the application. By default browsers hide templates from rendering on the page.
+The `template` element is for creating "special" content fragments for reuse later in the application. 
+By default, you won't see the contents of templates rendered in the page.  Templates are often used to 
+define the Shadow Tree for a component.
 
 ```html
 <template>
@@ -16,12 +18,11 @@ The `template` element is a Web Standard for creating content fragments for reus
 </template>
 ```
 
-The superpower :sparkles: of the `<template>` element is that it gets pre-parsed by the HTML parser into a reusable content fragment. Then when rendering to the page, it can skip the parsing step of the expensive parse → layout → reflow loop the browser does when JavaScript injects content on the page. 
-
+The superpower :sparkles: of the `<template>` element is that it gets parsed by the HTML parser into a reusable and "inert" content fragment.  That is, the browser will not attempt to do things like load replaced elements or execute scripts inside the template.  The fragement created and be worked with as a parsed tree and inserted into the DOM relatively cheaply.
 
 ## `<slot>`
 
-The `<slot>` element is a child element of `<template>` and provides a way to pass HTML content ("Light DOM") into a template. If you've ever used Vue's slots feature this should be familiar.
+The `<slot>` element is for use inside a Shadow tree.  It provides a way to expose a "hole" into the Shadow DOM which the consumer can use to provide HTML content ("Light DOM") which will be "projected".   If you've ever used Vue's slots feature this should be familiar.
 
 ```html
 <template>

--- a/docs/get-started/elements.md
+++ b/docs/get-started/elements.md
@@ -22,7 +22,9 @@ The superpower :sparkles: of the `<template>` element is that it gets parsed by 
 
 ## `<slot>`
 
-The `<slot>` element is for use inside a Shadow tree.  It provides a way to expose a "hole" into the Shadow DOM which the consumer can use to provide HTML content ("Light DOM") which will be "projected".   If you've ever used Vue's slots feature this should be familiar.
+The `<slot>` element creates a "hole" inside a web component's [Shadow DOM](/get-started/shadow-dom.html). We explain Shadow DOM later, but for now understand slots are a way to project your custom HTML content inside a web component. Not all web components have slots and Shadow DOM, but they are very common and one of web components' greatest superpowers :sparkles: 
+
+If you've ever used Vue's slots feature this should be familiar.
 
 ```html
 <template>

--- a/docs/get-started/elements.md
+++ b/docs/get-started/elements.md
@@ -18,7 +18,7 @@ define the Shadow Tree for a component.
 </template>
 ```
 
-The superpower :sparkles: of the `<template>` element is that it gets parsed by the HTML parser into a reusable and "inert" content fragment.  That is, the browser will not attempt to do things like load replaced elements or execute scripts inside the template.  The fragement created and be worked with as a parsed tree and inserted into the DOM relatively cheaply.
+The superpower :sparkles: of the `<template>` element is that it gets parsed by the HTML parser into a reusable and "inert" content fragment.  That is, the browser will not attempt to do things like load replaced elements or execute scripts inside the template.  The fragment can   be worked with as a parsed tree and inserted into the DOM relatively cheaply.
 
 ## `<slot>`
 

--- a/docs/get-started/elements.md
+++ b/docs/get-started/elements.md
@@ -10,7 +10,7 @@ Two handy elements for creating content fragments and passing content to compone
 
 The `template` element is for creating "special" content fragments for reuse later in the application. 
 By default, you won't see the contents of templates rendered in the page.  Templates are often used to 
-define the Shadow Tree for a component.
+define the Shadow tree for a component.
 
 ```html
 <template>

--- a/docs/get-started/elements.md
+++ b/docs/get-started/elements.md
@@ -4,7 +4,7 @@ title: "Template and Slot Elements"
 
 # Template and Slot Elements
 
-There are two elements which can be very useful in creating Web Components which you might not be familliar with: `<template>` and `<slot>`, for creating content fragments and passing content in to components.
+Two handy elements for creating content fragments and passing content to components you might not be familiar with are <template> and <slot>.
 
 ## `<template>`
 


### PR DESCRIPTION
Reading this I had a few thoughts and it was kind of difficult to find a way to make the right comments, so I tried seeing if I could just suggest a PR... Really, feel free to reject this or take what you want from it - but at least maybe this helps me explain the comments in case it is useful at all?

"The web components specification" - I get this is meant in a broad way, but it does kind of imply that there is one which will be (has been, in my experience) confusing to people coming to it from those words. If it's easy to avoid the confusion, probably worth it?

The other bit I changed about that is because `<template>` predates web components really.. It came about because lots of us were already abusing other things, like `<script type="text/somethingunknown">` for this purpose - but that has some undesirable things, like that it would try to load an `<img src=${foo}>` or would have trouble with if that itself contained scripts, etc.  So _really_ the superpower of template is that it parses very specially as an 'inert' (different definition) tree which you can use all of the handy DOM/query methods on, but also isn't an 'active' part of the tree.. it was a big change to the parser.

For `<slot>` my real thought was just that it's specifically about shadow trees and it's not tied to templates.. slots can be anywhere in a shadow tree, so I also removed "child".  Templates are definitely a common way of defining the shadow tree so I see how this gets confusing to explain simply.


Idk, this is all, I realize very nitpicky - feel free to close and ignore it if you feel that's best.

