### PR TITLE
fix: Missing "this" in brewery app code

### DIFF
--- a/docs/examples/example-app/step2.md
+++ b/docs/examples/example-app/step2.md
@@ -25,7 +25,7 @@ class BreweryApp extends LitElement {
       <p>Found ${this.breweries.length} breweries</p>
 
       <ul>
-        ${breweries.map(
+        ${this.breweries.map(
           brewery => html`
             <li>${brewery.name}</li>
           `,

--- a/docs/examples/example-app/step3.md
+++ b/docs/examples/example-app/step3.md
@@ -39,7 +39,7 @@ class BreweryApp extends LitElement {
       <p>Found ${this.breweries.length} breweries</p>
 
       <ul>
-        ${breweries.map(
+        ${this.breweries.map(
           brewery => html`
             <li>${brewery.name}</li>
           `,

--- a/docs/examples/example-app/step4.md
+++ b/docs/examples/example-app/step4.md
@@ -42,7 +42,7 @@ class BreweryApp extends LitElement {
       <p>(${totalVisited} visited and ${totalNotVisited} still to go)</p>
 
       <ul>
-        ${breweries.map(
+        ${this.breweries.map(
           brewery => html`
             <li>
               <h3>${brewery.name}</h3>

--- a/docs/examples/example-app/step5.md
+++ b/docs/examples/example-app/step5.md
@@ -53,7 +53,7 @@ class BreweryApp extends LitElement {
       <button @click=${() => {this.filter = 'not-visited'}}>Filter not-visited</button>
 
       <ul>
-        ${breweries.map(
+        ${this.breweries.map(
           brewery => html`
             <li>
               <h3>${brewery.name}</h3>

--- a/docs/examples/example-app/step6.md
+++ b/docs/examples/example-app/step6.md
@@ -23,7 +23,7 @@ class BreweryApp extends LitElement {
       <button @click=${this._filterNotVisited}>Filter not-visited</button>
 
       <ul>
-        ${breweries.map(
+        ${this.breweries.map(
           brewery => html`
             <li>
               <brewery-template


### PR DESCRIPTION
## What this does 
Adds a missing "this" to the examples for building a brewery app with Lit: 

``` Javascript
 ${this.breweries.map(
          brewery => html`
            <li>
              <brewery-template
                .brewery="${brewery}"
                .toggleVisitedStatus=${() => this.toggleVisitedStatus(brewery)}>
              </brewery-template>
            </li>
          `,
        )}
```

Without it, the example code loads but indefinitely shows "Loading" text instead of the list of Minneapolis breweries. (Which is a lovely sight, as a Minneapolis local!)